### PR TITLE
Potential fix for code scanning alert no. 2: Query built by concatenation with a possibly-untrusted string

### DIFF
--- a/app/src/main/java/workshop05code/SQLiteConnectionManager.java
+++ b/app/src/main/java/workshop05code/SQLiteConnectionManager.java
@@ -145,10 +145,11 @@ public class SQLiteConnectionManager {
      * @return true if guess exists in the database, false otherwise
      */
     public boolean isValidWord(String guess) {
-        String sql = "SELECT count(id) as total FROM validWords WHERE word like'" + guess + "';";
+        String sql = "SELECT count(id) as total FROM validWords WHERE word like ?;";
 
         try (Connection conn = DriverManager.getConnection(databaseURL);
                 PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, guess);
 
             ResultSet resultRows = stmt.executeQuery();
             if (resultRows.next()) {
@@ -162,6 +163,5 @@ public class SQLiteConnectionManager {
             System.out.println(e.getMessage());
             return false;
         }
-
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/MQ-COMP3310/w05sqlinjectionpub-DucHuyVu1007/security/code-scanning/2](https://github.com/MQ-COMP3310/w05sqlinjectionpub-DucHuyVu1007/security/code-scanning/2)

To fix the problem, we should use a prepared statement instead of concatenating the `guess` parameter directly into the SQL query. Prepared statements allow us to safely include user input in SQL queries by using placeholders and setting the parameter values separately. This approach prevents SQL injection attacks by ensuring that user input is treated as data rather than executable code.

Specifically, we need to:
1. Modify the SQL query to use a placeholder (`?`) for the `guess` parameter.
2. Use the `setString` method to set the value of the `guess` parameter in the prepared statement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
